### PR TITLE
added inventory command

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -76,6 +76,8 @@ pub enum Command {
     Save(Option<String>),
     /// Loads game state from file
     Load(String),
+    // Outputs the player's current inventory 
+    Inventory,
     /// Represents an unrecognized command.
     Unknown,
 }
@@ -117,6 +119,9 @@ impl FromStr for Command {
                 } else {
                     Ok(Command::Unknown)
                 }
+            },
+            "inventory" | "inv" => {
+                Ok(Command::Inventory)
             }
             _ => Ok(Command::Unknown),
         }
@@ -249,7 +254,7 @@ impl GameEngine {
 
         let output = match cmd {
             Command::Help => {
-                "Available commands: help, quit, exit, rest, gather, status".to_string()
+                "Available commands: help, quit, exit, rest, gather, status, inventory".to_string()
             }
             Command::Rest => {
                 self.player.health = (self.player.health + 20).min(100);
@@ -329,6 +334,10 @@ impl GameEngine {
                     }
                     _ => "Couldn't gather unknown resource!".to_string(),
                 }
+            },
+            Command::Inventory => {
+                let player_inventory = &self.player.inventory;
+                format!("~ {} lb. of firewood\n~ {} L of water\n~ {} lb. of food", player_inventory.wood, player_inventory.water, player_inventory.food)
             }
             _ => "Unknown command!".to_string(),
         };
@@ -472,6 +481,20 @@ mod tests {
     }
 
     #[test]
+    fn test_engine_inventory_command_output() {
+        let mut engine = GameEngine::new();
+        let output = engine.process_command("inventory");
+        assert!(output.contains("L of water") && output.contains("lb. of firewood") && output.contains("lb. of food"));
+    }
+
+    #[test]
+    fn test_engine_inventory_command_shorthand() {
+        let mut engine = GameEngine::new();
+        let output = engine.process_command("inv");
+        assert!(output.contains("~"));
+    }
+
+    #[test]
     fn test_engine_death() {
         let mut engine = GameEngine::new();
         engine.player.health = 0;
@@ -506,7 +529,7 @@ mod tests {
         // Gather commands have variable costs, but always at least 1
         let mut engine2 = GameEngine::new();
         engine2.process_command("gather wood");
-        assert!(engine2.time.hour >= WAKE_UP_HOUR + 1 && engine2.time.hour <= WAKE_UP_HOUR + 3);
+        assert!(engine2.time.hour > WAKE_UP_HOUR && engine2.time.hour <= WAKE_UP_HOUR + 3);
 
         // Rest command jumps to next day WAKE_UP_HOUR
         engine2.process_command("rest");

--- a/tests/features/inventory.feature
+++ b/tests/features/inventory.feature
@@ -1,0 +1,32 @@
+Feature: Inventory Command
+  As a player
+  I want to check my inventory
+  So that I know what resources I have gathered
+
+  Scenario: Checking empty inventory
+    Given the game is running
+    When I type the command "inventory"
+    Then the output should contain "~ 0 lb. of firewood"
+    And the output should contain "~ 0 L of water"
+    And the output should contain "~ 0 lb. of food"
+    And the game should still be running
+
+  Scenario: Checking inventory with multiple resources
+    Given the game is running
+    When I type the command "gather wood"
+    And I type the command "gather water"
+    And I type the command "gather food"
+    And I type the command "inventory"
+    Then the output should contain "lb. of firewood"
+    And the output should contain "L of water"
+    And the output should contain "lb. of food"
+    And the game should still be running
+
+  Scenario: Using inventory shorthand command
+    Given the game is running
+    When I type the command "inv"
+    Then the output should contain "~ 0 lb. of firewood"
+    And the output should contain "~ 0 L of water"
+    And the output should contain "~ 0 lb. of food"
+    And the game should still be running
+


### PR DESCRIPTION
This pull request introduces a new "inventory" command to the game engine, allowing players to view their current resources at any time. The implementation includes support for both the full "inventory" command and its shorthand "inv", updates the help text, and adds comprehensive tests to ensure correct behavior. Additionally, feature tests have been added to verify user-facing functionality.

**New Inventory Command Functionality:**

- Added a new `Inventory` variant to the `Command` enum and implemented parsing for both "inventory" and "inv" inputs. [[1]](diffhunk://#diff-ff278ec599adfd033d35a083ebe8948db8bf177c9817dee8ddc4f3a9e3f5728eR79-R80) [[2]](diffhunk://#diff-ff278ec599adfd033d35a083ebe8948db8bf177c9817dee8ddc4f3a9e3f5728eR122-R124)
- Implemented the handling of the `Inventory` command in the `GameEngine`, formatting and displaying the player's current resources.
- Updated the help text to include the new "inventory" command.

**Testing and Feature Coverage:**

- Added unit tests for both the "inventory" and "inv" commands to ensure correct output and shorthand support.
- Introduced a new feature file `inventory.feature` with scenarios covering empty inventory, inventory after gathering resources, and the shorthand command.

**Minor Fixes:**

- Adjusted a test assertion for gather command timing to ensure accuracy.